### PR TITLE
修复ThreadLocal引起的串户的问题

### DIFF
--- a/src/main/java/com/github/hcsp/controller/AuthController.java
+++ b/src/main/java/com/github/hcsp/controller/AuthController.java
@@ -44,6 +44,8 @@ public class AuthController {
     @ResponseBody
     public LoginResult logout() {
         SecurityContextHolder.clearContext();
+        // logout要清理掉在ThreadLocal中保存的用户
+        UserContext.removeUser();
         return UserContext.getCurrentUser()
                 .map(user -> LoginResult.success("success", false))
                 .orElse(LoginResult.failure("用户没有登录"));

--- a/src/main/java/com/github/hcsp/service/UserContext.java
+++ b/src/main/java/com/github/hcsp/service/UserContext.java
@@ -13,6 +13,10 @@ public class UserContext {
     public static Optional<User> getCurrentUser() {
         return Optional.ofNullable(currentUser.get());
     }
+
+    public static void removeUser() {
+        currentUser.remove();
+    }
 //
 //
 //    public Optional<User> getCurrentUser() {


### PR DESCRIPTION
我们登录时向`ThreadLocal`储存了当前的用户，但是我们登出时没有删除掉这个用户，导致登出之后再检查状态时会获取已经保存在`ThreadLocal`用户状态。

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

