### PR TITLE
user已经注销，但usercontext不为空

### DIFF
--- a/src/main/java/com/github/hcsp/service/UserContextInterceptor.java
+++ b/src/main/java/com/github/hcsp/service/UserContextInterceptor.java
@@ -26,6 +26,8 @@ public class UserContextInterceptor implements HandlerInterceptor {
             User user = userService.getUserByUsername(authentication.getName());
             if (user != null) {
                 UserContext.setCurrentUser(user);
+            }else{
+                UserContext.currentUser.remove();
             }
         }
         return true;


### PR DESCRIPTION
该线程曾经处理过User，所以userContext中存过cookie，但是后来user注销了，此时又轮到该线程，user为空，但userContext中不为空，所以后续报错。

<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

