### PR TITLE
解决了在用户退出后ThreadLocal没有释放的问题

### DIFF
--- a/src/main/java/com/github/hcsp/service/UserContextInterceptor.java
+++ b/src/main/java/com/github/hcsp/service/UserContextInterceptor.java
@@ -30,4 +30,10 @@ public class UserContextInterceptor implements HandlerInterceptor {
         }
         return true;
     }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler,
+                                Exception ex) {
+        UserContext.currentUser.remove();
+    }
 }


### PR DESCRIPTION
<!--- 你要打开的这个Pull request(PR)的类型是？默认是题目解答，如果你正在修复当前的仓库的缺陷，请选择对应的类型 -->

- [x] 这个PR解答了当前仓库中的题目（机器人会自动判题并合并当前PR）
- [ ] 这个PR修复了当前仓库中的一些代码缺陷（机器人不会判题，而是由管理员来处理当前PR）

